### PR TITLE
CI: Enable testing on macOS

### DIFF
--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         toolchain:
           - stable
     steps:


### PR DESCRIPTION
For whatever reason, the `highs` crate seems now to building fine, even though we're using the same version we were before.

Either way: fixes https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/43