### PR TITLE
CI: Fix: Requests to crates.io need extra header

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,10 @@
+{
+    "httpHeaders": [
+        {
+            "urls": ["https://crates.io/"],
+            "headers": {
+                "Accept": "text/html"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
`markdown-link-check` is currently failing for a URL on crates.io. It turns out you need to pass an extra HTTP header for this to work.

(Thanks to @cc-a for figuring this out!)

Fixes #4.