### PR TITLE
Fix: Approve bot PRs before enabling auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,7 +13,9 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
     steps:
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           # GitHub provides this variable in the CI env. You don't


### PR DESCRIPTION
The workflow to auto-merge dependabot PRs is currently not working. We need an approving review for all PRs, so without it the bot PRs just stay open forever.
